### PR TITLE
Revert "hotfix: Display `/img/no-image.png` even if the value of `post.hero.image` in News data is an empty string."

### DIFF
--- a/dist/biography/index.html
+++ b/dist/biography/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/biography.css?202411162230"
+  href="/css/biography.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/contact/index.html
+++ b/dist/contact/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/contact.css?202411162230"
+  href="/css/contact.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/discography/ep/350.html
+++ b/dist/discography/ep/350.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/discography-detail.css?202411162230"
+  href="/css/discography-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/discography/ep/nigiri.html
+++ b/dist/discography/ep/nigiri.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/discography-detail.css?202411162230"
+  href="/css/discography-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/discography/ep/shindarahone.html
+++ b/dist/discography/ep/shindarahone.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/discography-detail.css?202411162230"
+  href="/css/discography-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/discography/ep/souonshu.html
+++ b/dist/discography/ep/souonshu.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/discography-detail.css?202411162230"
+  href="/css/discography-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/discography/ep/wasabi.html
+++ b/dist/discography/ep/wasabi.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/discography-detail.css?202411162230"
+  href="/css/discography-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/discography/farmhouse/ep/paddle.html
+++ b/dist/discography/farmhouse/ep/paddle.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/discography-detail.css?202411162230"
+  href="/css/discography-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/discography/farmhouse/ep/pedal.html
+++ b/dist/discography/farmhouse/ep/pedal.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/discography-detail.css?202411162230"
+  href="/css/discography-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/discography/farmhouse/single/kutsushita.html
+++ b/dist/discography/farmhouse/single/kutsushita.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/discography-detail.css?202411162230"
+  href="/css/discography-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/discography/farmhouse/single/tokyo-flat-seat.html
+++ b/dist/discography/farmhouse/single/tokyo-flat-seat.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/discography-detail.css?202411162230"
+  href="/css/discography-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/discography/farmhouse/single/wall.html
+++ b/dist/discography/farmhouse/single/wall.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/discography-detail.css?202411162230"
+  href="/css/discography-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/discography/feat/lumos-makishima.html
+++ b/dist/discography/feat/lumos-makishima.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/discography-detail.css?202411162230"
+  href="/css/discography-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/discography/feat/pocket-full-of-gum.html
+++ b/dist/discography/feat/pocket-full-of-gum.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/discography-detail.css?202411162230"
+  href="/css/discography-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/discography/index.html
+++ b/dist/discography/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/discography.css?202411162230"
+  href="/css/discography.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/discography/record/gari.html
+++ b/dist/discography/record/gari.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/discography-detail.css?202411162230"
+  href="/css/discography-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/discography/record/shindarahone.html
+++ b/dist/discography/record/shindarahone.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/discography-detail.css?202411162230"
+  href="/css/discography-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/discography/santena/ep/i-want-a-car.html
+++ b/dist/discography/santena/ep/i-want-a-car.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/discography-detail.css?202411162230"
+  href="/css/discography-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/discography/single/drug.html
+++ b/dist/discography/single/drug.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/discography-detail.css?202411162230"
+  href="/css/discography-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/discography/single/kinishinai.html
+++ b/dist/discography/single/kinishinai.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/discography-detail.css?202411162230"
+  href="/css/discography-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/discography/single/kousokudouro.html
+++ b/dist/discography/single/kousokudouro.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/discography-detail.css?202411162230"
+  href="/css/discography-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/discography/single/nandemodekiru.html
+++ b/dist/discography/single/nandemodekiru.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/discography-detail.css?202411162230"
+  href="/css/discography-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/discography/single/new-year-card-2023-usagi.html
+++ b/dist/discography/single/new-year-card-2023-usagi.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/discography-detail.css?202411162230"
+  href="/css/discography-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/goods/index.html
+++ b/dist/goods/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/goods.css?202411162230"
+  href="/css/goods.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/index.html
+++ b/dist/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/home.css?202411162230"
+  href="/css/home.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/index.html
+++ b/dist/news/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news.css?202411162230"
+  href="/css/news.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post001/index.html
+++ b/dist/news/post001/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post002/index.html
+++ b/dist/news/post002/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post003/index.html
+++ b/dist/news/post003/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post004/index.html
+++ b/dist/news/post004/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post005/index.html
+++ b/dist/news/post005/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post006/index.html
+++ b/dist/news/post006/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post007/index.html
+++ b/dist/news/post007/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post008/index.html
+++ b/dist/news/post008/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post009/index.html
+++ b/dist/news/post009/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post010/index.html
+++ b/dist/news/post010/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post011/index.html
+++ b/dist/news/post011/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post012/index.html
+++ b/dist/news/post012/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post013/index.html
+++ b/dist/news/post013/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post014/index.html
+++ b/dist/news/post014/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post015/index.html
+++ b/dist/news/post015/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post016/index.html
+++ b/dist/news/post016/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post017/index.html
+++ b/dist/news/post017/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post018/index.html
+++ b/dist/news/post018/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post019/index.html
+++ b/dist/news/post019/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post020/index.html
+++ b/dist/news/post020/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post021/index.html
+++ b/dist/news/post021/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post022/index.html
+++ b/dist/news/post022/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post023/index.html
+++ b/dist/news/post023/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post024/index.html
+++ b/dist/news/post024/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post025/index.html
+++ b/dist/news/post025/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post026/index.html
+++ b/dist/news/post026/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post027/index.html
+++ b/dist/news/post027/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post028/index.html
+++ b/dist/news/post028/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post029/index.html
+++ b/dist/news/post029/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post030/index.html
+++ b/dist/news/post030/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post031/index.html
+++ b/dist/news/post031/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post032/index.html
+++ b/dist/news/post032/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post033/index.html
+++ b/dist/news/post033/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post034/index.html
+++ b/dist/news/post034/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post035/index.html
+++ b/dist/news/post035/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post036/index.html
+++ b/dist/news/post036/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post037/index.html
+++ b/dist/news/post037/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post038/index.html
+++ b/dist/news/post038/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post039/index.html
+++ b/dist/news/post039/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post040/index.html
+++ b/dist/news/post040/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post041/index.html
+++ b/dist/news/post041/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post042/index.html
+++ b/dist/news/post042/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post043/index.html
+++ b/dist/news/post043/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post044/index.html
+++ b/dist/news/post044/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post045/index.html
+++ b/dist/news/post045/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post046/index.html
+++ b/dist/news/post046/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post047/index.html
+++ b/dist/news/post047/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post048/index.html
+++ b/dist/news/post048/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post049/index.html
+++ b/dist/news/post049/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post050/index.html
+++ b/dist/news/post050/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post051/index.html
+++ b/dist/news/post051/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post052/index.html
+++ b/dist/news/post052/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post053/index.html
+++ b/dist/news/post053/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post054/index.html
+++ b/dist/news/post054/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post055/index.html
+++ b/dist/news/post055/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post056/index.html
+++ b/dist/news/post056/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post057/index.html
+++ b/dist/news/post057/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post058/index.html
+++ b/dist/news/post058/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post059/index.html
+++ b/dist/news/post059/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post060/index.html
+++ b/dist/news/post060/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post061/index.html
+++ b/dist/news/post061/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post062/index.html
+++ b/dist/news/post062/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post063/index.html
+++ b/dist/news/post063/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post064/index.html
+++ b/dist/news/post064/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post065/index.html
+++ b/dist/news/post065/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post066/index.html
+++ b/dist/news/post066/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post067/index.html
+++ b/dist/news/post067/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post068/index.html
+++ b/dist/news/post068/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post069/index.html
+++ b/dist/news/post069/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post070/index.html
+++ b/dist/news/post070/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post071/index.html
+++ b/dist/news/post071/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post072/index.html
+++ b/dist/news/post072/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post073/index.html
+++ b/dist/news/post073/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post074/index.html
+++ b/dist/news/post074/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/news/post075/index.html
+++ b/dist/news/post075/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/news-detail.css?202411162230"
+  href="/css/news-detail.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/dist/picture/look/summer-vacation/index.html
+++ b/dist/picture/look/summer-vacation/index.html
@@ -61,7 +61,7 @@
 />
 <link
   rel="stylesheet"
-  href="/css/picture-post.css?202411162230"
+  href="/css/picture-post.css?202411162138"
 />
 <link
   rel="shortcut icon"

--- a/src/ejs/_inc/components/news/_news.ejs
+++ b/src/ejs/_inc/components/news/_news.ejs
@@ -15,7 +15,7 @@
           <figure class="card__image-area">
             <img
               class="card__thumbnail<%= post?.hero?.image ? '' : ' card__thumbnail--no-image' %>"
-              src="<%- (post?.hero?.image && post.hero.image !== '') ? post.hero.image : '/img/no-image.png' %>"
+              src="<%- post?.hero?.image || '/img/no-image.png' %>"
               alt="<%- post?.hero?.alt || 'No image' %>"
             />
           </figure>


### PR DESCRIPTION
This reverts commit 472a32bcb35fff931b0734f0775284eb323706a1.

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

